### PR TITLE
Update Conference -> Workshop for title of workshop

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -64,7 +64,7 @@ const Hero = () => {
             level={3}
             className="text-center font-semibold ml-2 mt-2 text-secondary-600 dark:text-secondary-400"
           >
-            Conference: {CONFERENCE.workshopDate} | Venue:{' '}
+            Workshop: {CONFERENCE.workshopDate} | Venue:{' '}
           </Span>
           <Link
             className="underline font-semibold ml-1 mt-2 text-secondary-600 dark:text-secondary-400"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**Summary:**
* Main page has conference mentioned twice instead of workshop. 

![image](https://github.com/user-attachments/assets/e5810aef-08cd-4d63-a800-edfb06f16e14)


<!-- Please write a short summary of the changes. -->

**Issue Link:**

#94 

<!-- Please use "fix #123" style references so the issue is closed when this PR is merged. -->

**PR Checks:**

- [x] Code is properly formatted (executed `make pre-push` command).
- [x] No ESLint warnings (verified with `make pre-push` command).
- [x] UI Changes are responsive (checked in the responsive view).
- [x] Performance is maintained (Lighthouse report reviewed).
- [x] User experience (UX) considerations are met.
- [x] Accessibility is supported (validated with accessibility tools).